### PR TITLE
Support rocket-chip's JTAG DTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,19 @@ val tap = JtagTapGenerator(2, Map(myDataChain -> 1))
   - It is a bug if the generator can generate non-spec-compliant designs - if this happens, please file an issue!
   - Exception: boundary-scan is currently not implemented. Please don't file a bug for that, it will be implemented eventually.
 
+### Package Structure
+No guarantees are made about the contents of the `examples` folder. In particular, do NOT depend on the contents of those (such as the async tools) in your designs.
+
 ## Hardware Verification
 This generator has been used in these designs:
 - Example design on [ICE40HX8K-B-EVN (Lattice iCE40 FPGA) through Yosys](examples/ice40hx8k-yosys)
 
 Planned:
 - None currently.
+
+## More Debugging Modules
+Check out the [builtin-debuggers](https://github.com/ucb-art/builtin-debugger) repository, which contains generators for debugging blocks like a logic analyzer and pattern generator that you can instantiate on your chip or FPGA and connect it through JTAG.
+
 
 ## TODOs
 Some features are yet to be implemented:

--- a/src/main/scala/JtagStateMachine.scala
+++ b/src/main/scala/JtagStateMachine.scala
@@ -72,7 +72,7 @@ class JtagStateMachine extends Module(override_reset=Some(false.B)) {
     val tms = Input(Bool())
     val currState = Output(JtagState.State.chiselType())
 
-    val asyncReset = Input(Bool()) // TODO!
+    val asyncReset = Input(Bool())
   }
   val io = IO(new StateMachineIO)
 

--- a/src/main/scala/JtagStateMachine.scala
+++ b/src/main/scala/JtagStateMachine.scala
@@ -72,77 +72,72 @@ class JtagStateMachine extends Module(override_reset=Some(false.B)) {
     val tms = Input(Bool())
     val currState = Output(JtagState.State.chiselType())
 
-    val asyncReset = Input(Bool())
+    val jtag_reset = Input(Bool())
   }
   val io = IO(new StateMachineIO)
 
-  // TMS is captured as a single signal, rather than fed directly into the next state logic.
-  // This increases the state computation delay at the beginning of a cycle (as opposed to near the
-  // end), but theoretically allows a cleaner capture.
-  val tms = Reg(Bool(), next=io.tms)  // 4.3.1a captured on TCK rising edge, 6.1.2.1b assumed changes on TCK falling edge
-
   val nextState = Wire(JtagState.State.chiselType())
 
-  val lastStateReg = Module (new AsyncResetRegVec(w = JtagState.State.width,
+  val currStateReg = Module (new AsyncResetRegVec(w = JtagState.State.width,
     init = JtagState.State.toInt(JtagState.TestLogicReset)))
 
-  lastStateReg.clock := clock
-  lastStateReg.reset := io.asyncReset
-  lastStateReg.io.en := true.B
-  lastStateReg.io.d  := nextState
-  val lastState = lastStateReg.io.q
+  currStateReg.clock := clock
+  currStateReg.reset := io.jtag_reset
+  currStateReg.io.en := true.B
+  currStateReg.io.d  := nextState
 
+  val currState = currStateReg.io.q
 
-  io.currState := nextState
-
-  switch (lastState) {
+  switch (currState) {
     is (JtagState.TestLogicReset.U) {
-      nextState := Mux(tms, JtagState.TestLogicReset.U, JtagState.RunTestIdle.U)
+      nextState := Mux(io.tms, JtagState.TestLogicReset.U, JtagState.RunTestIdle.U)
     }
     is (JtagState.RunTestIdle.U) {
-      nextState := Mux(tms, JtagState.SelectDRScan.U, JtagState.RunTestIdle.U)
+      nextState := Mux(io.tms, JtagState.SelectDRScan.U, JtagState.RunTestIdle.U)
     }
     is (JtagState.SelectDRScan.U) {
-      nextState := Mux(tms, JtagState.SelectIRScan.U, JtagState.CaptureDR.U)
+      nextState := Mux(io.tms, JtagState.SelectIRScan.U, JtagState.CaptureDR.U)
     }
     is (JtagState.CaptureDR.U) {
-      nextState := Mux(tms, JtagState.Exit1DR.U, JtagState.ShiftDR.U)
+      nextState := Mux(io.tms, JtagState.Exit1DR.U, JtagState.ShiftDR.U)
     }
     is (JtagState.ShiftDR.U) {
-      nextState := Mux(tms, JtagState.Exit1DR.U, JtagState.ShiftDR.U)
+      nextState := Mux(io.tms, JtagState.Exit1DR.U, JtagState.ShiftDR.U)
     }
     is (JtagState.Exit1DR.U) {
-      nextState := Mux(tms, JtagState.UpdateDR.U, JtagState.PauseDR.U)
+      nextState := Mux(io.tms, JtagState.UpdateDR.U, JtagState.PauseDR.U)
     }
     is (JtagState.PauseDR.U) {
-      nextState := Mux(tms, JtagState.Exit2DR.U, JtagState.PauseDR.U)
+      nextState := Mux(io.tms, JtagState.Exit2DR.U, JtagState.PauseDR.U)
     }
     is (JtagState.Exit2DR.U) {
-      nextState := Mux(tms, JtagState.UpdateDR.U, JtagState.ShiftDR.U)
+      nextState := Mux(io.tms, JtagState.UpdateDR.U, JtagState.ShiftDR.U)
     }
     is (JtagState.UpdateDR.U) {
-      nextState := Mux(tms, JtagState.SelectDRScan.U, JtagState.RunTestIdle.U)
+      nextState := Mux(io.tms, JtagState.SelectDRScan.U, JtagState.RunTestIdle.U)
     }
     is (JtagState.SelectIRScan.U) {
-      nextState := Mux(tms, JtagState.TestLogicReset.U, JtagState.CaptureIR.U)
+      nextState := Mux(io.tms, JtagState.TestLogicReset.U, JtagState.CaptureIR.U)
     }
     is (JtagState.CaptureIR.U) {
-      nextState := Mux(tms, JtagState.Exit1IR.U, JtagState.ShiftIR.U)
+      nextState := Mux(io.tms, JtagState.Exit1IR.U, JtagState.ShiftIR.U)
     }
     is (JtagState.ShiftIR.U) {
-      nextState := Mux(tms, JtagState.Exit1IR.U, JtagState.ShiftIR.U)
+      nextState := Mux(io.tms, JtagState.Exit1IR.U, JtagState.ShiftIR.U)
     }
     is (JtagState.Exit1IR.U) {
-      nextState := Mux(tms, JtagState.UpdateIR.U, JtagState.PauseIR.U)
+      nextState := Mux(io.tms, JtagState.UpdateIR.U, JtagState.PauseIR.U)
     }
     is (JtagState.PauseIR.U) {
-      nextState := Mux(tms, JtagState.Exit2IR.U, JtagState.PauseIR.U)
+      nextState := Mux(io.tms, JtagState.Exit2IR.U, JtagState.PauseIR.U)
     }
     is (JtagState.Exit2IR.U) {
-      nextState := Mux(tms, JtagState.UpdateIR.U, JtagState.ShiftIR.U)
+      nextState := Mux(io.tms, JtagState.UpdateIR.U, JtagState.ShiftIR.U)
     }
     is (JtagState.UpdateIR.U) {
-      nextState := Mux(tms, JtagState.SelectDRScan.U, JtagState.RunTestIdle.U)
+      nextState := Mux(io.tms, JtagState.SelectDRScan.U, JtagState.RunTestIdle.U)
     }
   }
+
+  io.currState := currState
 }

--- a/src/main/scala/JtagStateMachine.scala
+++ b/src/main/scala/JtagStateMachine.scala
@@ -88,7 +88,7 @@ class JtagStateMachine extends Module(override_reset=Some(false.B)) {
 
   lastStateReg.clock := clock
   lastStateReg.reset := io.asyncReset
-  lastStateReg.io.en    := Bool(true)
+  lastStateReg.io.en := true.B
   lastStateReg.io.d  := nextState
   val lastState = lastStateReg.io.q
 

--- a/src/main/scala/JtagStateMachine.scala
+++ b/src/main/scala/JtagStateMachine.scala
@@ -71,7 +71,7 @@ class JtagStateMachine extends Module(override_reset=Some(false.B)) {
     val tms = Input(Bool())
     val currState = Output(JtagState.State.chiselType())
 
-    val asyncReset = Input(Bool())  // TODO: IMPLEMENT ME
+    val asyncReset = Input(Bool()) // TODO!
   }
   val io = IO(new StateMachineIO)
 

--- a/src/main/scala/JtagTap.scala
+++ b/src/main/scala/JtagTap.scala
@@ -80,6 +80,7 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt) extends Modul
   // TODO: 7.1.1d allow design-specific IR bits, 7.1.1e (rec) should be a fixed pattern
   // 7.2.1a behavior of instruction register and shifters
   val irShifter = Module(CaptureUpdateChain(UInt(irLength.W)))
+  irShifter.suggestName("irChain")
   irShifter.io.chainIn.shift := currState === JtagState.ShiftIR.U
   irShifter.io.chainIn.data := io.jtag.TDI
   irShifter.io.chainIn.capture := currState === JtagState.CaptureIR.U
@@ -156,6 +157,7 @@ object JtagTapGenerator {
     val allInstructions = idcode match {
       case Some((icode, idcode)) => {
         val idcodeModule = Module(CaptureChain(UInt(32.W)))
+        idcodeModule.suggestName("idcodeChain")
         require(idcode % 2 == 1, "LSB must be set in IDCODE, see 12.1.1d")
         require(((idcode >> 1) & ((1 << 11) - 1)) != JtagIdcode.dummyMfrId, "IDCODE must not have 0b00001111111 as manufacturer identity, see 12.2.1b")
         require(!(instructions contains icode), "instructions may not contain IDCODE")

--- a/src/main/scala/JtagTap.scala
+++ b/src/main/scala/JtagTap.scala
@@ -5,14 +5,14 @@ package jtag
 import chisel3._
 import chisel3.util._
 
-/** JTAG signals, viewed from the device side.
+/** JTAG signals, viewed from the master side
   */
-class JtagIO extends Bundle {
-  val TRSTn  = Input(Bool()) // TRST is an active-low signal. Name it accordingly.
-  val TCK   = Input(Bool())
-  val TMS   = Input(Bool())
-  val TDI   = Input(Bool())
-  val TDO   = Output(new Tristate())
+class JTAGIO extends Bundle {
+  val TRSTn  = Output(Bool()) // TRST is an active-low signal. Name it accordingly.
+  val TCK   = Clock(OUTPUT)
+  val TMS   = Output(Bool())
+  val TDI   = Output(Bool())
+  val TDO   = Input(new Tristate())
 }
 
 /** JTAG block output signals.
@@ -32,7 +32,7 @@ class JtagControl extends Bundle {
 /** Aggregate JTAG block IO.
   */
 class JtagBlockIO(irLength: Int) extends Bundle {
-  val jtag = new JtagIO
+  val jtag = Flipped(new JTAGIO())
   val control = new JtagControl
   val output = new JtagOutput(irLength)
 
@@ -71,7 +71,7 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt) extends Modul
   stateMachine.io.tms := io.jtag.TMS
   val currState = stateMachine.io.currState
   io.output.state := stateMachine.io.currState
-  stateMachine.io.asyncReset := io.control.fsmAsyncReset
+  stateMachine.io.asyncReset := io.control.fsmAsyncReset | ~io.jtag.TRSTn
 
   //
   // Instruction Register

--- a/src/main/scala/JtagTap.scala
+++ b/src/main/scala/JtagTap.scala
@@ -27,7 +27,7 @@ class JtagOutput(irLength: Int) extends Bundle {
 }
 
 class JtagControl extends Bundle {
-  val jtckPOReset = Input(Bool())
+  val jtag_reset = Input(Bool())
 }
 
 /** Aggregate JTAG block IO.
@@ -62,7 +62,7 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt) extends Modul
 
   val tdo = Wire(Bool())  // 4.4.1c TDI should appear here uninverted after shifting
   val tdo_driven = Wire(Bool())
-  io.jtag.TDO.data := NegativeEdgeLatch(clock, tdo, name = Some("tdoReg"))  // 4.5.1a TDO changes on falling edge of TCK or TRST, 6.1.2.1d driver active on first TCK falling edge in ShiftIR and ShiftDR states
+  io.jtag.TDO.data := NegativeEdgeLatch(clock, tdo, name = Some("tdoReg"))  // 4.5.1a TDO changes on falling edge of TCK, 6.1.2.1d driver active on first TCK falling edge in ShiftIR and ShiftDR states
   io.jtag.TDO.driven := NegativeEdgeLatch(clock, tdo_driven, name = Some("tdoeReg"))
 
   //
@@ -77,7 +77,7 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt) extends Modul
   // combined with any POR, and it should also be
   // synchronized to TCK.
   require(!io.jtag.TRSTn.isDefined, "TRSTn should be absorbed into jtckPOReset outside of JtagTapController.")
-  stateMachine.io.asyncReset := io.control.jtckPOReset
+  stateMachine.io.jtag_reset := io.control.jtag_reset
 
   //
   // Instruction Register

--- a/src/main/scala/JtagTap.scala
+++ b/src/main/scala/JtagTap.scala
@@ -8,11 +8,11 @@ import chisel3.util._
 /** JTAG signals, viewed from the device side.
   */
 class JtagIO extends Bundle {
-  // TRST (4.6) is optional and not currently implemented.
-  val TCK = Input(Bool())
-  val TMS = Input(Bool())
-  val TDI = Input(Bool())
-  val TDO = Output(new Tristate())
+  val TRSTn  = Input(Bool()) // TRST is an active-low signal. Name it accordingly.
+  val TCK   = Input(Bool())
+  val TMS   = Input(Bool())
+  val TDI   = Input(Bool())
+  val TDO   = Output(new Tristate())
 }
 
 /** JTAG block output signals.

--- a/src/main/scala/Utils.scala
+++ b/src/main/scala/Utils.scala
@@ -31,9 +31,10 @@ class NegativeEdgeLatch[T <: Data](clock: Clock, dataType: T)
 /** Generates a register that updates on the falling edge of the input clock signal.
   */
 object NegativeEdgeLatch {
-  def apply[T <: Data](clock: Clock, next: T, enable: Bool=true.B): T = {
+  def apply[T <: Data](clock: Clock, next: T, enable: Bool=true.B, name: Option[String] = None): T = {
     // TODO better init passing once in-module multiclock support improves
     val latch_module = Module(new NegativeEdgeLatch((!clock.asUInt).asClock, next.cloneType))
+    name.foreach(latch_module.suggestName(_))
     latch_module.io.next := next
     latch_module.io.enable := enable
     latch_module.io.output


### PR DESCRIPTION
I'm not really expecting this to be merged, just submitting it for your feedback.

With this, i was able to replace the  JTAG DTM in rocket-chip. 

I experimented with the asynchronously reset logic, but I'm not sure I'm using these as you'd expect. Here's what I currently have:

TRSTn -- external active-low input presumably from off-chip, but must be synchronized to TCK for dassert outside of this logic. Asynchronously resets jtagState to TEST_LOGIC_RESET. This signal should be totally optional -- if tied high the design should still work.

io.control.reset -- This is equivalent to (jtagState == TEST_LOGIC_RESET) but since that is asynchronously reset, it is itself an asynchronously asserted reset signal. I am taking that and using it as the reset for most of the logic running off TCK.

io.control.fsmAsyncReset -- this is driven by something I'm calling "jtagPOReset". I think in general you don't want to 

For all my debug logic I need to think about what reset domain it should really be in.

When you clear IR, it is not done asynchronously. What does the spec say for this? Should this be driven by the async reset as well?

In rocket-chip I believe it is the standard to have the master side of the interface as the non-flipped version, so here I flipped JTAGIO to match.

Finally someone suggested that  the negative edge clocking issues should be pushed to the edge of your design / chip, unless you really have a good reason to do it within the logic. Perhaps this could be added as an option in jtagTap and a utility function to apply  at the SoC top level.
